### PR TITLE
correct markdown linting errors

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,6 @@
   "default": true,
   "MD007": { "indent": 4 },
   "MD013": { "line_length": 1000 },
-  "MD033": { "allowed_elements": ["table", "tbody", "th", "tr", "td"] },
+  "MD033": { "allowed_elements": [] },
   "MD040": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,6 @@
   "default": true,
   "MD007": { "indent": 4 },
   "MD013": { "line_length": 1000 },
-  "MD033": { "allowed_elements": ["table", "tbody", "th", "tr", "td"] }
+  "MD033": { "allowed_elements": ["table", "tbody", "th", "tr", "td"] },
+  "MD040": false
 }

--- a/src/pages/docs/main-concepts/1. organizational-structure.md
+++ b/src/pages/docs/main-concepts/1. organizational-structure.md
@@ -11,19 +11,25 @@ The following diagram depicts the B2B organization structure as represented by O
 ![Organizational Structure](../images/organizational-structure.svg)
 
 ## Sellers Organization
+
 At the highest level is the seller organization; meaning, data is not meant to be shared from seller to seller. Ultimately a seller organization exists to own and manage the users, catalogs, and orders within it. The administrators who maintain the buyers' functions (for example customer service representatives or catalog/product managers) are termed seller users and belong directly to the seller organization.
 
 ## Companies
+
 Seller organizations can also be categorized as a company, along with Buyers and Suppliers. Companies represent the unique entities within OrderCloud that transact and manage relationships with one another. Each type of company has its own purpose.
 
 ### Seller
+
 As stated earlier, the seller is the root node of any OrderCloud solution whose main purpose is to maintain the buyers' functions. Typical functions include but are not limited to: Managing products and prices, creating and setting approval rules, defining available shipping and billing addresses for buyer users, and so on.
 
 ### Buyer
+
 Each seller organization can contain multiple buyers. These entities do exactly what you might think, they buy products from the seller. There are various ways that buyers can be configured. For instance, OrderCloud supports buyer networks; imagine a franchise or marketplace use case where many buyer companies have access to the same buying experience. Alternatively, you can create an independent login for each buyer company to custom tailor a unique buyer experience for each company.
 
 ### Supplier
+
 Similar to buyers, sellers can contain more than one supplier. They exist on the same hierarchical plane as buyers; however, their purpose is generally geared towards order fulfillment. Unlike sellers and buyers, suppliers are not required to create a functional OrderCloud solution.
 
 ## User Groups
+
 Within each type of company mentioned above, user groups are available to simplify the management of a large user base. Sellers can create highly personalized experiences for users within each type of company by taking advantage of user group level relationships. Each user can be assigned to multiple groups within their company and they will inherit all of the relationships between those groups and the data associated with them. We will see more fully how this system of assignments works in the following section.

--- a/src/pages/docs/main-concepts/2. assignments.md
+++ b/src/pages/docs/main-concepts/2. assignments.md
@@ -7,6 +7,7 @@ title: "Assignments"
 Now that we have an understanding of the various ordercloud parties (companies and groups) we can begin to talk about assignments. When you save an assignment you are creating a relationship between a party and an object (ordercloud "thing" such as product, category, etc). For example you might assign a usergroup to a category, thereby granting a user in that group visibility to that category.
 
 There are basic principles around how assignments work that are critical to understanding our data model and more importantly how the data model can be applied to solve the most complex ordering scenarios efficiently
+
 - Assignments are used to define a relationship
 - Assignments are inclusive
 - Assignments can be made at different levels
@@ -14,9 +15,11 @@ There are basic principles around how assignments work that are critical to unde
 - Assignments are many to many
 
 ## Assignments are Inclusive
+
 When a user is created they exist in a vacuum. The user will not have access to any objects until an assignment is made to them directly, or through a higher level party assignment.
 
-## Assignments can be made at different levels
+## Assignments Can Be Made at Different Levels
+
 Assignments can be made at the company level (buyer, seller, supplier) or any usergroup within one of those companies. 
 
 ## Assignments Cascade Down Higher Levels to the Individual User
@@ -24,7 +27,9 @@ Assignments can be made at the company level (buyer, seller, supplier) or any us
 When the API is looking for what a given user has access to, it is checking for assignments. If that user is a member of a party that has an assignment to that object, then that user also has access to that object. Regardless of where an assignment is saved, all of these objects are presented to the user seamlessly and in a very flat structure.
 
 ## Assignments are Many to Many
+
 Resources can be assigned to many different parties. Those parties can be assigned to many other resources. For example, one user can be assigned to multiple address while one address can be assigned to multiple users.
 
 ## Conclusion
+
 You should now have an understanding of how assignments work from the admin perspective, but generally as an individual user you don't really care about the how or why, you just want to know what you're assigned to. The `Me` resource which we'll talk about next has the distinct role of rolling up and flattening any assignments to the individual user.

--- a/src/pages/docs/main-concepts/3. me-resource.md
+++ b/src/pages/docs/main-concepts/3. me-resource.md
@@ -5,17 +5,19 @@ date: 2019-06-24T23:33:21.852Z
 ---
 
 ## Me Resource
+
 Multi-tiered assignments make up a powerful mechanism for customizing the buyer experience down to the individual user. But once configured, the buyer (and developer for that matter) wants a fast and intuitive experience that's more concerned with what they see rather than how or why they see it.
 
+## Easy Access to What the Currently Authenticated User Owns
 
-## Easy access to what the currently authenticated user owns
 OrderCloud provides the `Me` resource whose job it is to flatten these assignments for the currently authenticated user and just "show me what I can see" regardless at which level these assignments are made.
 
 For example let's say your buyer user is assigned an address at the buyer level, and another address at the usergroup level. Instead of listing assignments between the user and both those levels and manually resolving the addresses yourself, you can simply make a list call as that buyer user to [me/addresses](TODO:link-to-me-addresses) and quickly get the assigned addresses in one quick and fluid motion.
 
-## Ability to admin personal resources
+## Ability to Admin Personal Resources
+
 In addition to being able to quickly get information about the currently authenticated user, the Me resource provides a set of admin endpoints for personal resources (Credit Cards and Addresses) that only that user can see. Not even admins have access to viewing the data created by these users without something like [impersonation](TODO:link-to-impersonation-feature).
 
+## Conclusion
 
-## Overview
 We've seen how assignments can be made and flow down to the individual user, and how easy it is by using the `Me` resource to get those assignments. In the next section we're going to talk about Security Profiles which let you lock down which endpoints a user can access.

--- a/src/pages/docs/main-concepts/4. security-profiles.md
+++ b/src/pages/docs/main-concepts/4. security-profiles.md
@@ -5,14 +5,17 @@ date: 2019-06-24T23:33:21.852Z
 ---
 
 ## Overview
+
 Security profiles are a seller level resource made up of a group of roles (permissions) that grant a user access to specific endpoints in the ordercloud API when assigned. If a request is made by a user without sufficient roles, they will receive a 403 Forbidden response.
 
 ## Roles
+
 Most Ordercloud roles fall into one of two categories: Admin and Reader. An **Admin** role allows read and write access to a resource while a **Reader** role allows only read access.
 
-For example, a user that is assigned a security profile that has the role `PromotionReader` will be able to Get or List Promotions but will not be able to call write endpoints such as Save, Patch, Delete or make any kind of assignments. In order to do that they would need to be assigned `PromotionAdmin` which has the same read abilities **plus** write abilities. 
+For example, a user that is assigned a security profile that has the role `PromotionReader` will be able to Get or List Promotions but will not be able to call write endpoints such as Save, Patch, Delete or make any kind of assignments. In order to do that they would need to be assigned `PromotionAdmin` which has the same read abilities **plus** write abilities.
 
 All of our resources are protected at minimum by Admin and Reader roles. By defining access at this granular level we enable you to build an application that adheres to the principle of least privelege, giving your users access to only the endpoints they absolutely need access to.
 
 ## Conclusion
+
 We've purposely kept the information here at a high level but if you want to dive a little deeper into security profiles and their roles, check out our [feature guide](TODO:link-tosecurityprofiles-feature). Otherwise, let's keep on moving and dive into authentication

--- a/src/pages/docs/main-concepts/5. catalog-structure.md
+++ b/src/pages/docs/main-concepts/5. catalog-structure.md
@@ -7,14 +7,17 @@ title: "Catalog Structure"
 To understand a catalog, we will begin by understanding the individual pieces.
 
 ## Categories
+
 Categories are useful to present, sort, and further segment products in an organized way. Categories can have parent categories which enables the creation of a hierarchical structure of arbitrary depth.
 ![TODO:add-graphic-of-category-hierarchy]
 
 ## Catalogs
+
 When a category is created it must be defined as part of a catalog. There is a direct parent/child relationship between any category and exactly one catalog.
 ![TODO:add-graphic-of-category-hierarchy-within-catalog]
 
 ## Product Assignments
+
 Products don't really live inside categories or catalogs in the same way that categories live inside a catalog. They exist independent of both those entities but can be assigned to either, which allows the API to present the product as part of them (at least to the user).
 
 ![TODO:add-graphic-of-category-hierarchy-within-catalog-with-product-assignments-products-existing-outside]

--- a/src/pages/docs/main-concepts/6. product-visibility.md
+++ b/src/pages/docs/main-concepts/6. product-visibility.md
@@ -7,6 +7,7 @@ title: "Product Visibility"
 Product visibility is without a doubt one of the most complex things you'll encounter in OrderCloud but by the end of this guide you will be familiar with all the different ways product visibility works and will be educated enough to choose a method that works best for your use case. Feel free to skip ahead to the [visibility cheat sheet](#product-visibility-cheat-sheet) if prefer a condensed version.
 
 ## Traditional Product Visibility
+
 Let's outline the basic steps you'll need to make a product visible to a user in the traditional way. This allows you to define visibility at the most granular level and is best suited for the most complex applications.
 
 1. Create a catalog structure (just like in previous section)
@@ -15,30 +16,32 @@ Let's outline the basic steps you'll need to make a product visible to a user in
 4. Create [price schedule](TODO:link-to-api-reference)
 5. Create [three point assignment](TODO:link-to-method) between the product, price schedule, and usergroup
 
-Step four is really where all the magic happens. It introduces a unique three point assignment between the product, priceschedule, and usergroup. This defines what the price on the product will be for the users in that usergroup. 
+Step four is really where all the magic happens. It introduces a unique three point assignment between the product, priceschedule, and usergroup. This defines what the price on the product will be for the users in that usergroup.
 
 [TODO:link-to-image]
-
 
 It might be intuitive to see price as a property of a product but by decoupling any price related things (price schedule) from the product we can represent the same product at different prices to different users. Let's say we want that same product to be have a different price for a different user. No problem!
 
 [TODO:image-with-sameproduct-two-prices]
 
-
 Hopefully you can begin seeing the power and flexibility we gain by using assignments. By the way, unique pricing is really just skimming the surface of what we can do with price schedules. A price schedule can do things like set min or max quantity, restrict quantity to set intervals, and even track inventory!
 
 ## Simpler Product Visibility
+
 That’s a fair amount of work, and although it gives you extremely precise control over who sees what, it’s often more control than you really need, which can make catalog management overly burdensome.
 
-In 2017 we rolled out a powerful new set of features aimed at simplifying catalog management for cases where you don’t need such fine-grained control. Let’s explore these features by use case. 
+In 2017 we rolled out a powerful new set of features aimed at simplifying catalog management for cases where you don’t need such fine-grained control. Let’s explore these features by use case.
 
 ### Scenario 1: "I want control over who sees what, but pricing usually doesn’t vary from buyer to buyer."
+
 For this scenario you should use **default price schedules**. Just populate `DefaultPriceScheduleID` on the product model, leave it out of the `ProductAssignments`, and those assigned parties will get the default pricing. `ProductAssignment` still has a `PriceScheduleID`, and it takes precedence over the default, but it is now optional. Giving each product a default price schedule is recommended in the majority of cases.
 
 ### Scenario 2: "I want to allow some users to *see* certain products but not *buy* them."
+
 This is a case where you would **NOT** use a default price schedule. If other visibility requirements are met but neither `Product.DefaultPriceSchedule` nor any `ProductAssignment.PriceScheduleID` related to the user is populated, the product will be visible to the user but not purchase-able.
 
 ### Scenario 3: "When I assign a catalog to a buyer organization, I just want everybody in that organization to see everything in the catalog."
+
 If your visibility rules are fairly simple, you’ll appreciate this one. `CatalogAssignment` (the relationship between Catalog and Buyer organization) has these two properties: `ViewAllCategories` and `ViewAllProducts`. And yup, setting them to `true` does exactly what you think it does. These settings tend to go hand in hand with default price schedules; without those, you'd need to create product assignments anyway just to get pricing in place.
 
 ### Scenario 4: "I want to control visibility at the category level, but when I assign a category, I want all products and subcategories within it to be visible to the assigned party automatically."
@@ -46,6 +49,7 @@ If your visibility rules are fairly simple, you’ll appreciate this one. `Catal
 Here we get a little more fine-grained with assignments, but still not all the way down to individual products. You’ll want `CatalogAssignment.ViewAllCategories` and `CatalogAssignment.ViewAllProducts` set to `false`, and set `CategoryAssignment.Visible` and `CategoryAssignment.ViewAllProducts` to `true` as needed. Note that while `CatalogAssignment` can only be applied to an entire buyer organization, `CategoryAssignment` can apply to the entire organization or a user group within it.
 
 ### Scenario 5: "I want everybody to see everything except a specific category."
+
 `CategoryAssignment.Visible` and `CategoryAssignment.ViewAllProducts` have 3 possible values: `true`, `false`, or `null`. `null` means “inherit this setting from my parent”, i.e. the parent category or, in the case of top-level categories, the catalog. This is a very powerful concept - it means you turn on `ViewAllCategories` and `Vi.ewAllProducts` on the `CatalogAssignment`, and then turn off either or both anywhere down the category tree. Category-level settings, whether true or false, will always override their corresponding catalog-level settings.
 
 ### Scenario 6: "I want to temporarily hide an entire catalog from all buyers it’s assigned to."
@@ -53,14 +57,14 @@ Here we get a little more fine-grained with assignments, but still not all the w
 Product and Category have always had an Active bit, independent of assignments, that allows you to effectively hide it from everyone by setting it to `false`. We are now adding an Active bit at the Catalog level as well.
 
 ### Scenario 7: "I want a search-driven catalog where products do not belong to categories."
-We’ve already discussed that a product’s assignment to a buyer party (`ProductAssignment`) is no longer required for visibility. The same holds true for a product’s assignment to a category. As long as `CatalogAssignment.ViewAllProducts` is `true`, the only requirement for a product to become visible via search or direct link is the existence of a `CatalogProductAssignment`. (Note: This assignment is technically required in all product visibility scenarios. If you do not create one before assigning the product to a category, it will be created implicitly. But if it doesn’t exist before creating a `ProductAssignment`, an error will occur. No more "floating" product-party relationships - the Catalog is King!)
 
+We’ve already discussed that a product’s assignment to a buyer party (`ProductAssignment`) is no longer required for visibility. The same holds true for a product’s assignment to a category. As long as `CatalogAssignment.ViewAllProducts` is `true`, the only requirement for a product to become visible via search or direct link is the existence of a `CatalogProductAssignment`. (Note: This assignment is technically required in all product visibility scenarios. If you do not create one before assigning the product to a category, it will be created implicitly. But if it doesn’t exist before creating a `ProductAssignment`, an error will occur. No more "floating" product-party relationships - the Catalog is King!)
 
 We're confident that most OrderClould developers will find at least a subset of these new features useful. Getting to know them now and taking advantage of them whenever possible will relieve you of many catalog maintenance headaches down the road.
 
-
 ## Product Visibility Cheat Sheet
-**Visibility Rules**
+
+### Visibility Rules
 
 All of the following must be true for a Buyer User to see a Product (via me routes):
 
@@ -79,7 +83,6 @@ All of the following must be true for a Buyer User to see a Product (via me rout
             - ViewAllProducts = true for first non-null setting up the tree
     - ProductAssignment exists for Buyer or any Group the user belongs to (PriceScheduleID not required)
 
-**Validation Rules**
+### Validation Rules
 
 In order to create a ProductAssignment, the Buyer and Product must be assigned to a common Catalog (via CatalogAssignment and CatalogProductAssignment).
-

--- a/src/pages/docs/main-concepts/authentication.md
+++ b/src/pages/docs/main-concepts/authentication.md
@@ -13,13 +13,15 @@ OrderCloud's authentication system is built on top of an open authorization stan
 Access tokens are what gives you *access* to parts of the API and must be appended to every request. Encrypted in the token are the identity of the user as well as the roles that the user has access to. Once validated, the ordercloud API has enough information from this token to determine which endpoints and data a user can read and/or write.
 
 ## API Client
+
 Every authentication request is done through an [API Client](TODO:add-link-to-api-client). If your organization is a house think of an API Client as one of the doors to your house where each door can be configured to allow up to three different types of users from entering: buyers, sellers, and suppliers.
 
-You'll probably have an API Client for your buyer application that only lets buyer users sign in, another one for your seller application that only lets seller users in and possibly one for your integration user which only allows that seller user in. 
+You'll probably have an API Client for your buyer application that only lets buyer users sign in, another one for your seller application that only lets seller users in and possibly one for your integration user which only allows that seller user in.
 
 In general, an API Client is another way defining access to your organization.
 
 ## 1. Password Workflow
+
 This is the most common workflow you'll see. A user is providing their username/password and is logging in to an application.
 
 | Parameter  | Definition                    |
@@ -29,7 +31,6 @@ This is the most common workflow you'll see. A user is providing their username/
 | password   | the user's password           |
 | grant_type | value must be `password`      |
 
-
 ```https
 POST https://auth.ordercloud.io/oauth/token HTTP/1.1
 Content-Type: text/html; charset=UTF-8
@@ -37,8 +38,8 @@ Content-Type: text/html; charset=UTF-8
 client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&username=xxxxxxxx&password=xxxxxxxx&grant_type=password
 ```
 
-
 ## 2. Client Credentials Workflow
+
 This workflow is best suited for where you need a way for your integration to get a token. Instead of a username and password you're essentially authenticating directly through that client using a ClientID and a ClientSecret.
 
 To use this workflow you'll need to set the ClientSecret on the API Client in the [Console](TODO:link-to-console)
@@ -56,12 +57,11 @@ Content-Type: text/html; charset=UTF-8
 client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&client_secret=xxxxxxxxxxxxx&grant_type=client_credentials
 ```
 
-
 ## 3. Anonymous Shopping or Guest Checkout Workflow
-You might want to enable visitors to browse a catalog of products and/or checkout without registering themselves. We call this [Anonymous Shopping](TODO:add-link-to-anon-shopping-guide) or Guest Checkout. 
+
+You might want to enable visitors to browse a catalog of products and/or checkout without registering themselves. We call this [Anonymous Shopping](TODO:add-link-to-anon-shopping-guide) or Guest Checkout.
 
 Before you can make a request to get a token via this workflow you must ensure that your API client has a template user defined by setting the user in the [Console](TODO:-add-link-to-console). Without a template user the API has no context for determining data the anonymous user has access to, like product and pricing information.
-
 
 | Parameter  | Definition                         |
 |------------|------------------------------------|
@@ -76,7 +76,8 @@ client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&grant_type=client_credentials
 ```
 
 ## 4. Refresh Workflow
-Access tokens will expire after some pre-determined time (set on the API Client in the console) after which you will need to get another access token in order to continue interacting with the API. Without a refresh token a user might have to re-enter their username and password to get a new token however if you have enabled refresh tokens you will receive a refresh token on your initial authentication request which you can save and then use to get another access token when your initial access token expires. 
+
+Access tokens will expire after some pre-determined time (set on the API Client in the console) after which you will need to get another access token in order to continue interacting with the API. Without a refresh token a user might have to re-enter their username and password to get a new token however if you have enabled refresh tokens you will receive a refresh token on your initial authentication request which you can save and then use to get another access token when your initial access token expires.
 
 >Refresh tokens are disabled by default. To enable refresh tokens you'll need to set the expiration time on refresh tokens to be greater than zero. This expiration time is defined on the API client and can be set in the console.
 
@@ -121,7 +122,6 @@ OrderCloud enables single sign on via OpenID Connect which is yet another standa
 At a high level OrderCloud allows your users to log into the OrderCloud API by logging into any identity provider you trust such as Facebook, Google, or even an ERP system you own. It prevents your users the hassle of having to manage one more set of credentials.
 
 A detailed guide for using OpenID Connect with OrderCloud can be found [here](TODO:-link-to-OpenID-connect-guide)
-
 
 ### Overview
 

--- a/src/pages/docs/markdown-template.md
+++ b/src/pages/docs/markdown-template.md
@@ -72,12 +72,29 @@ Below is a table with four columns and three rows
 
 A standard ordered list
 
+```plaintext
+1. First item
+2. Second item
+3. Third item
+4. Fourth item
+```
+
 1. First item
 2. Second item
 3. Third item
 4. Fourth item
 
 An ordered list with a sub set list
+
+```
+1. First item
+2. Second item
+    1. Indented
+3. Third item
+    1. Indented
+    2. Indented
+4. Fourth item
+```
 
 1. First item
 2. Second item
@@ -88,6 +105,15 @@ An ordered list with a sub set list
 4. Fourth item
 
 ### Unordered Lists
+
+```
+- First item
+- Second item
+- Third item
+    - Indented item
+    - Indented item
+- Fourth item
+```
 
 - First item
 - Second item


### PR DESCRIPTION
- Remove trailing white spaces and add line in between headers and paragraphs
- Title Case headings
- Remove unused `allowed_elements` from markdown lint config