### PR TITLE
fix: dont build algolia index locally

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,7 +64,7 @@ const queries = [
     settings,
   },
 ]
-module.exports = {
+const toExport = {
   siteMetadata: {
     title: `OrderCloud Documentation`,
     description: `Documentation for OrderCloud's B2B eCommerce API`,
@@ -78,16 +78,6 @@ module.exports = {
     `gatsby-plugin-sharp`,
     `gatsby-plugin-typescript`,
     `gatsby-transformer-sharp`,
-    {
-      resolve: `gatsby-plugin-algolia`,
-      options: {
-        appId: process.env.GATSBY_ALGOLIA_APP_ID,
-        apiKey: process.env.GATSBY_ALGOLIA_ADMIN_API_KEY,
-        indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME, // for all queries
-        queries,
-        chunkSize: 10000, // default: 1000
-      },
-    },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
@@ -152,4 +142,20 @@ module.exports = {
       },
     },
   ],
+}
+
+module.exports = toExport
+if (process.env.GATSBY_ALGOLIA_ADMIN_API_KEY) {
+  // for local development, don't store GATSBY_ALGOLIA_ADMIN_API_KEY
+  // because it will rebuild the algolia index
+  toExport.plugins.push({
+    resolve: `gatsby-plugin-algolia`,
+    options: {
+      appId: process.env.GATSBY_ALGOLIA_APP_ID,
+      apiKey: process.env.GATSBY_ALGOLIA_ADMIN_API_KEY,
+      indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME, // for all queries
+      queries,
+      chunkSize: 10000, // default: 1000
+    },
+  })
 }


### PR DESCRIPTION
The way we had it previously the algolia index would rebuild anytime we built it locally. We generally only need it when it deploys and it costs money to do it. 

The way it works now is that if `process.env.GATSBY_ALGOLIA_ADMIN_API_KEY` exists then it will index algolia. Its therefore recommended to remove that environment variable from both `env.development` and `.env.production`. This gives us a little escape hatch in the rare scenarios where we might want to generate it locally (we'd just set that value)