### PR TITLE
#146 - Design / SEO updates

### DIFF
--- a/content/release-notes/v1.0.134.mdx
+++ b/content/release-notes/v1.0.134.mdx
@@ -1,0 +1,8 @@
+---
+apiVersion: 1.0.134
+date: 2020-01-17
+---
+
+- Bug fix: PATCHing any string property where only the casing of the string changes will stick.
+- Bug fix: Suppliers can add their own ship-from Address to a Product without receiving an error.
+- Bug fix: Line items on a submitted order can be PATCHed without error after the corresponding Product has been deleted.

--- a/src/components/Layout/ApiReferenceMenu.tsx
+++ b/src/components/Layout/ApiReferenceMenu.tsx
@@ -59,6 +59,7 @@ const useStyles = makeStyles((theme: Theme) =>
                 : defaultColor,
               marginBottom: theme.spacing(1),
               maxWidth: '80%',
+              fontWeight: 'bold' as any,
             }
           case 'resource':
             return {

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -152,6 +152,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     const { classes, location, width, data } = this.props
     const { anchorEl, auth } = this.state
     const isMobile = width !== 'md' && width !== 'lg' && width !== 'xl'
+    const isMedium = width !== 'lg' && width !== 'xl'
     const currentApiVersion = data.allMdx.nodes[0].frontmatter.apiVersion
     let activeTab = 'docs'
     if (location && location.pathname) {
@@ -325,10 +326,14 @@ class Header extends React.Component<HeaderProps, HeaderState> {
               classes={{
                 searchBox: `${isMobile ? classes.mobileSearchBox : undefined}`,
                 searchBoxInput: `${
-                  isMobile ? classes.mobileSearchInput : undefined
+                  isMobile
+                    ? classes.mobileSearchInput
+                    : isMedium
+                    ? classes.mediumSearchInput
+                    : undefined
                 }`,
               }}
-              placeholder={isMobile && 'Search...'}
+              placeholder={isMedium && 'Search...'}
               darkMode={true}
               noPopper={isMobile}
             ></DocSearch>
@@ -480,6 +485,9 @@ const styles = (theme: Theme) =>
       backgroundColor: 'rgba(0, 0, 0, .1)',
     },
     tab: {
+      fontFamily: theme.typography.h1.fontFamily,
+      letterSpacing: 1,
+      fontWeight: 'normal',
       minWidth: 0,
       cursor: 'pointer',
       transition: 'background-color .5s',
@@ -510,6 +518,9 @@ const styles = (theme: Theme) =>
     },
     mobileSearchBox: {
       marginRight: -theme.spacing(1),
+    },
+    mediumSearchInput: {
+      width: 100,
     },
     mobileSearchInput: {
       paddingTop: theme.spacing(1),

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme: Theme) =>
       backgroundColor: 'white',
       minHeight: `calc(100vh - ${navHeight}px)`,
       [theme.breakpoints.up('md')]: {
-        marginBottom: theme.spacing(52.25),
+        marginBottom: theme.spacing(51),
       },
       '& img': {
         maxWidth: '100%',
@@ -100,6 +100,11 @@ export default (props: LayoutProps) => {
             name: 'viewport',
             content:
               'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no',
+          },
+          {
+            name: 'description',
+            content:
+              'OrderCloud powers custom eCommerce (B2B, B2C, B2X), order management, and B2B marketplace applications for some of the world’s most well-known brands - processing over 25 million transactions and over $5 billion in revenue annually.',
           },
         ]}
       >

--- a/src/components/Layout/Main.tsx
+++ b/src/components/Layout/Main.tsx
@@ -41,16 +41,16 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     paperRoot: {
       zIndex: 1,
-      minHeight: '100%',
-      height: '100%',
+      flexGrow: 1,
     },
     paperCard: {
       position: 'relative',
       flexFlow: 'column nowrap',
       alignItems: 'center',
       maxWidth: '100vw',
+      padding: theme.spacing(2),
       [theme.breakpoints.up('md')]: {
-        minHeight: '30vh',
+        height: '100%',
       },
     },
     paperTitleHeading: {
@@ -121,7 +121,7 @@ const MainComponent: React.FunctionComponent = props => {
     <React.Fragment>
       <Jumbotron
         image={{ src: ocLogo, alt: 'Four51 OrderCloud Logo' }}
-        heading="A Next Generation Headless eCommerce Platform"
+        heading="A Next-Generation Headless eCommerce Platform"
         actions={[
           <CustomButtonLink
             color="#fff"
@@ -154,40 +154,58 @@ const MainComponent: React.FunctionComponent = props => {
                 key={index}
                 className={classes.paperRoot}
               >
-                <Paper elevation={5}>
-                  <Box p={2} zIndex={1}>
-                    <div className={classes.paperCard}>
-                      <Typography
-                        className={classes.paperTitleHeading}
-                        variant="h3"
-                      >
-                        {section.title}
-                      </Typography>
-                      <Typography
-                        className={classes.paperTitleSubheading}
-                        variant="subtitle1"
-                      >
-                        {getSectionSubtitle(section.title)}
-                      </Typography>
-                      <List
-                        disablePadding={true}
-                        dense={true}
-                        className={classes.paperList}
-                      >
-                        {section.guides.map(g => {
-                          return (
-                            <ListItemLink key={g.id} to={g.path}>
-                              {g.frontmatter.title}
-                            </ListItemLink>
-                          )
-                        })}
-                      </List>
-                    </div>
-                  </Box>
+                <Paper elevation={5} className={classes.paperCard}>
+                  <Typography
+                    className={classes.paperTitleHeading}
+                    variant="h3"
+                  >
+                    {section.title}
+                  </Typography>
+                  <Typography
+                    className={classes.paperTitleSubheading}
+                    variant="subtitle1"
+                  >
+                    {getSectionSubtitle(section.title)}
+                  </Typography>
+                  <List
+                    disablePadding={true}
+                    dense={true}
+                    className={classes.paperList}
+                  >
+                    {section.guides.map(g => {
+                      return (
+                        <ListItemLink key={g.id} to={g.path}>
+                          {g.frontmatter.title}
+                        </ListItemLink>
+                      )
+                    })}
+                  </List>
                 </Paper>
               </Grid>
             ))}
         </Grid>
+      </Container>
+      <Container maxWidth="md">
+        <Box paddingTop={7} paddingBottom={14}>
+          <Typography variant="h3">
+            Four51 OrderCloud™ is an API-first, headless eCommerce platform
+            offering nearly limitless customizations and endless freedom for
+            growth.
+          </Typography>
+          <Typography paragraph>
+            Your eCommerce data and infrastructure are available in the cloud as
+            building blocks via our RESTful API. Create best-of-breed commerce
+            applications that easily integrate with your back-end systems and
+            3rd party microservices. With OrderCloud, accelerate your commerce
+            transformation, increase your agility, and scale limitlessly.
+          </Typography>
+          <Typography>
+            OrderCloud powers custom eCommerce (B2B, B2C, B2X), order
+            management, and B2B marketplace applications for some of the world’s
+            most well-known brands - processing over 25 million transactions and
+            over $5 billion in revenue annually.
+          </Typography>
+        </Box>
       </Container>
     </React.Fragment>
   )

--- a/src/components/Shared/ApiReference/ApiSchemaTable.tsx
+++ b/src/components/Shared/ApiReference/ApiSchemaTable.tsx
@@ -11,6 +11,7 @@ import {
   TableHead,
   TableRow,
   Theme,
+  Typography,
 } from '@material-ui/core'
 import { ExpandLess, ExpandMore } from '@material-ui/icons'
 import React, { useCallback, useMemo, useState } from 'react'
@@ -34,6 +35,11 @@ const useStyles = makeStyles((theme: Theme) =>
     requiredChip: {
       backgroundColor: red[500],
       color: 'white',
+    },
+    rowWithDescription: {
+      '& > td': {
+        borderBottom: 'none',
+      },
     },
     string: {
       color: flame[600],
@@ -109,7 +115,11 @@ const ApiSchemaTable = (props: ApiSchemaTableProps) => {
             const isExpanded = expanded.includes(name)
             return (
               <React.Fragment key={name}>
-                <TableRow>
+                <TableRow
+                  className={
+                    field.description ? classes.rowWithDescription : undefined
+                  }
+                >
                   <TableCell padding={hasSubSchema ? 'checkbox' : undefined}>
                     {hasSubSchema && (
                       <IconButton
@@ -148,6 +158,15 @@ const ApiSchemaTable = (props: ApiSchemaTableProps) => {
                     {field.maxLength ? `${field.maxLength} characters` : '---'}
                   </TableCell>
                 </TableRow>
+                {field.description && (
+                  <TableRow>
+                    <TableCell colSpan={5} style={{ paddingTop: 0 }}>
+                      <Typography variant="caption">
+                        {field.description}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
                 {hasSubSchema && (
                   <TableRow>
                     <TableCell

--- a/src/components/Shared/DocSearch/CustomSearchBox.tsx
+++ b/src/components/Shared/DocSearch/CustomSearchBox.tsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles((theme: Theme) =>
         : theme.palette.grey[200],
     }),
     input: (props: any) => ({
+      fontFamily: theme.typography.h1.fontFamily,
       padding: theme.spacing(2, 1, 2, 0),
       width: 200,
       transition: theme.transitions.create('width', {

--- a/src/components/Templates/ApiReferenceTemplate.tsx
+++ b/src/components/Templates/ApiReferenceTemplate.tsx
@@ -46,8 +46,8 @@ interface ApiReferenceProps extends RouteComponentProps {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     breadcrumbs: {
-      paddingTop: theme.spacing(1.5),
-      marginBottom: -theme.spacing(4.5),
+      paddingTop: theme.spacing(5),
+      marginBottom: -theme.spacing(2.5),
     },
     breadcrumbLink: {
       textDecoration: 'none',
@@ -85,11 +85,11 @@ const ApiReference: FC<ApiReferenceProps> = (props: ApiReferenceProps) => {
   const defaultDescription =
     'OrderCloud is a cloud-hosted B2B eCommerce platform exposed entirely via a RESTful API. It enables rapid development of custom, secure, and scalable B2B eCommerce solutions. Spin up a fully functional B2B app in minutes and customize it to limits of your imagination.'
   const pageInfo = useMemo(() => {
-    const prefix = 'OrderCloud API'
+    const prefix = 'Four51 OrderCloud'
     const { section, resource, operation, menuData, currentPath } = pageContext
     if (operation) {
       return {
-        title: `${prefix} | ${operation.summary}`,
+        title: `${prefix} | ${operation.summary.replace(/\./g, '')}`,
         description: resource.description,
       }
     }
@@ -110,14 +110,19 @@ const ApiReference: FC<ApiReferenceProps> = (props: ApiReferenceProps) => {
       }
     }
     return {
-      title: `${prefix} Reference`,
+      title: `${prefix} | API Reference`,
     }
   }, [pageContext])
   return (
     <Layout location={location}>
       <Helmet
         title={pageInfo.title}
-        description={pageInfo.description || defaultDescription}
+        meta={[
+          {
+            name: 'description',
+            content: pageInfo.description || defaultDescription,
+          },
+        ]}
       />
       {!pageContext.section && (
         <React.Fragment>
@@ -168,6 +173,7 @@ const ApiReference: FC<ApiReferenceProps> = (props: ApiReferenceProps) => {
             <Breadcrumbs className={classes.breadcrumbs}>
               <Typography
                 className={classes.breadcrumbLink}
+                variant="body2"
                 component={Link}
                 to="/api-reference"
               >
@@ -176,6 +182,7 @@ const ApiReference: FC<ApiReferenceProps> = (props: ApiReferenceProps) => {
               {pageContext.resource && (
                 <Typography
                   className={classes.breadcrumbLink}
+                  variant="body2"
                   component={Link}
                   to={`/api-reference/${Case.kebab(
                     pageContext.section['x-id']
@@ -187,6 +194,7 @@ const ApiReference: FC<ApiReferenceProps> = (props: ApiReferenceProps) => {
               {pageContext.operation && pageContext.resource && (
                 <Typography
                   className={classes.breadcrumbLink}
+                  variant="body2"
                   component={Link}
                   to={`/api-reference/${Case.kebab(
                     pageContext.section['x-id']

--- a/src/components/Templates/BlogTemplate.tsx
+++ b/src/components/Templates/BlogTemplate.tsx
@@ -28,7 +28,15 @@ function BlogComponent(props: BlogComponentProps) {
   const { data, location } = props
   return (
     <Layout location={location}>
-      <Helmet title={`${data.mdx.frontmatter.title} - OrderCloud Blog`} />
+      <Helmet
+        title={`OrderCloud Blog | ${data.mdx.frontmatter.title}`}
+        meta={[
+          {
+            name: 'description',
+            content: data.mdx.frontmatter.summary,
+          },
+        ]}
+      />
       <LayoutContainer>
         <LayoutMain>
           <Typography variant="h1">{data.mdx.frontmatter.title}</Typography>

--- a/src/components/Templates/DocTemplate.tsx
+++ b/src/components/Templates/DocTemplate.tsx
@@ -33,9 +33,7 @@ export default function Template(props: DocTemplateProps) {
 
   return (
     <Layout location={props.location}>
-      <Helmet
-        title={`${doc.mdx.frontmatter.title} - OrderCloud Documentation`}
-      />
+      <Helmet title={`Four51 OrderCloud | ${doc.mdx.frontmatter.title}`} />
       <LayoutContainer>
         <LayoutMain>
           <Typography variant="h1">{doc.mdx.frontmatter.title}</Typography>

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -167,7 +167,16 @@ export default function BlogListComponent(props: BlogListProps) {
   `)
   return (
     <Layout location={props.location}>
-      <Helmet title={`OrderCloud Blog`} />
+      <Helmet
+        title={`OrderCloud Blog`}
+        meta={[
+          {
+            name: 'description',
+            content:
+              'New feature announcements, tips & tricks, and best practices to help developers get the most out of the OrderCloud platform.',
+          },
+        ]}
+      />
       <Jumbotron
         heading="OrderCloud Blog"
         text="New feature announcements, tips & tricks, and best practices to help developers get the most out of the OrderCloud platform."

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet'
 
 export default () => (
   <Layout>
-    <Helmet title={`OrderCloud Documentation`} />
+    <Helmet title={`Four51 OrderCloud`} />
     <Main />
   </Layout>
 )

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -61,7 +61,7 @@ export default function SlackCommunityComoponent(props: SlackCommunityProps) {
   return (
     <Layout>
       <div className={classes.slackLayout}>
-        <Helmet title={`OrderCloud Slack Community`} />
+        <Helmet title={`Join the OrderCloud Slack Community`} />
         <Paper elevation={3} className={classes.cardSignIn}>
           <Box display="flex" flexDirection="column" alignItems="center">
             <SvgIcon viewBox="0 0  270 270" className={classes.svgIcon}>

--- a/src/theme/theme.constants.tsx
+++ b/src/theme/theme.constants.tsx
@@ -103,7 +103,8 @@ export default createMuiTheme({
     },
     MuiButton: {
       label: {
-        paddingTop: 2,
+        fontFamily: headingFontFamilies,
+        // paddingTop: 2,
       },
     },
     MuiTypography: {


### PR DESCRIPTION
- Using the convention of "Four51 OrderCloud | xxx" for most pages with the exception of "OrderCloud Blog" pages.
- Added field.description to the ApiSchemaTable component (for request/response body documentation)
- Updated font family to Geometria for content within the Header.tsx (this will need to be updated on Portal as well so they match). This also meant I had to modify when the Search placeholder changes so that all items still fit on the sm/md breakpoints.