### PR TITLE
Make API Reference headingSpan pointer-events:none

### DIFF
--- a/src/components/Shared/ApiReference/ApiHeading.tsx
+++ b/src/components/Shared/ApiReference/ApiHeading.tsx
@@ -50,6 +50,7 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'block',
       marginTop: -120,
       paddingBottom: 120,
+      pointerEvents: 'none',
     },
   })
 )


### PR DESCRIPTION
This will allow users to highlight text that appears behind the fake heading - such as the ApiRoute
