### PR TITLE
Small Documentation Changes (Default Buyer Catalogs, Shipping an Order)

### DIFF
--- a/content/learn/order-fulfillment/shipping-an-order.mdx
+++ b/content/learn/order-fulfillment/shipping-an-order.mdx
@@ -16,7 +16,7 @@ Let's go ahead and use the shorthand method of shipping and completing an order 
 <CodeExample
   title="Ship and complete an order"
   content={{
-    http: `GET https://sandboxapi.ordercloud.io/v1/orders/incoming/INSERT_ORDER_ID_HERE/complete HTTP/1.1
+    http: `GET https://sandboxapi.ordercloud.io/v1/orders/incoming/INSERT_ORDER_ID_HERE/ship HTTP/1.1
 Authentication: Bearer INSERT_ACCESS_TOKEN_HERE
 Content-Type: application/json; charset=UTF-8;`,
 javascript: `import { Orders } from "ordercloud-javascript-sdk";\n
@@ -27,7 +27,7 @@ Orders.Ship("Incoming", "INSERT_ORDER_ID_HERE")
 })
 .catch(err => console.log(err));`,
 typescript: `import { Orders, Order, OrderCloudError } from "ordercloud-javascript-sdk";\n
-Orders.Complete("Incoming", "INSERT_ORDER_ID_HERE")
+Orders.Ship("Incoming", "INSERT_ORDER_ID_HERE")
   .then((response: Order) => {
       // returns the completed order
       console.log(response);

--- a/content/learn/product-catalogs/default-buyer-catalog.mdx
+++ b/content/learn/product-catalogs/default-buyer-catalog.mdx
@@ -10,7 +10,7 @@ In the previous chapter, you [established API access](/learn/getting-started/est
 ## What is a Catalog?
 Catalogs are a container of products and, optionally, categories. As a seller, your role is to sell products to your buyers through one or more catalogs. To do so, your catalog must be active and assigned to a buyer organization or user group.
 
-When a buyer organization is created, a default catalog is automatically created. You can find the ID of this catalog on the [buyer organization model](/api-reference/buyers/buyers/get) under `DefaultCatalogID`. The buyer you created in the last chapter should look something like this:
+When a buyer organization is created, a default catalog is automatically created along with it. You can find the ID of this catalog on the [buyer organization model](/api-reference/buyers/buyers/get) under `DefaultCatalogID`. The buyer you created in the last chapter should look something like this:
 
 ```json
 {

--- a/content/learn/product-catalogs/default-buyer-catalog.mdx
+++ b/content/learn/product-catalogs/default-buyer-catalog.mdx
@@ -10,7 +10,7 @@ In the previous chapter, you [established API access](/learn/getting-started/est
 ## What is a Catalog?
 Catalogs are a container of products and, optionally, categories. As a seller, your role is to sell products to your buyers through one or more catalogs. To do so, your catalog must be active and assigned to a buyer organization or user group.
 
-Each buyer organization has a default catalog that is created automatically with the. You can find the ID of this catalog on the [buyer organization model](/api-reference/buyers/buyers/get) under `DefaultCatalogID`. The buyer you created in the last chapter should look something like this:
+When a buyer organization is created, a default catalog is automatically created. You can find the ID of this catalog on the [buyer organization model](/api-reference/buyers/buyers/get) under `DefaultCatalogID`. The buyer you created in the last chapter should look something like this:
 
 ```json
 {


### PR DESCRIPTION
Changed a sentence in the Default Buyer Catalogs reference doc - looked like a typo there.
Changed code samples to use the right endpoint/method in the Shipping an Order reference doc.

If you have any questions, please contact me on teams - Rejaie Johnson, rejaie.johnson@sitecore.com, rej@sitecore.net.