### PR TITLE
Update line item level promo

### DIFF
--- a/content/documents/line-item-promos.mdx
+++ b/content/documents/line-item-promos.mdx
@@ -24,7 +24,7 @@ To remove any ambiguity (a central theme of this feature), you must first declar
 
 The existing `items` functions aren't quite enough to determine which item(s) to associate with a promo. Simple example: buy product X and get product Y for free. You can imagine writing your `EligibleExpression` with a pair of `items.any`, and it'll work, but we won't know which of the 2 items to tie the discount to.
 
-Enter the new `item` (singular) token. When used in an `EligibleExpression`, think of it as sort of a selector of the line item(s) that you want the promo applied to. Any property of the full-blown `LineItem` model is valid on `item` in an expression, as is the `incategory` function. In the example above, the `EligibleExpression` would be:
+Enter the new `item` (singular) token. When used in an `EligibleExpression`, think of it as sort of a selector of the line item (or multiple line items) that you want the promo applied to. Any property of the full-blown `LineItem` model is valid on `item` in an expression, as is the `incategory` function. In the example above, the `EligibleExpression` would be:
 
 ```
 item.ProductID = 'Y' and items.any(ProductID = 'X')


### PR DESCRIPTION
Feedback from confused community member. Making it more clear that the `item` token can be used to target multiple line items