### PR TITLE
Wrong next step in the Portal Dashboard section.

### DIFF
--- a/content/learn/getting-started/welcome-to-ordercloud.mdx
+++ b/content/learn/getting-started/welcome-to-ordercloud.mdx
@@ -23,9 +23,9 @@ You will need to provide an email address and validate ownership before continui
 ## Portal Dashboard
 Once you have successfully registered, you can log in and view the Portal dashboard. Here you can view invitations to organizations, view or create new organizations, and quickly access recently used API Console tabs. We will cover all of these topics in more detail soon. For right now, just know that this will serve as a central hub in your day-to-day experience with OrderCloud.
 
-Below we cover some of the basic account settings available. These aren't absolutely necessary for the _Getting Started_ journey so if you wish you can skip ahead and star the _"Creating Your First Organization"_ guide
+Below we cover some of the basic account settings available. These aren't absolutely necessary for the _Getting Started_ journey so if you wish you can skip ahead and star the _"Creating Your First Marketplace"_ guide
 
-<ContentLink to="/learn/getting-started/creating-your-first-organization" subtitle="Next Up" >Creating Your First Organization</ContentLink>
+<ContentLink to="/learn/getting-started/creating-your-first-marketplace" subtitle="Next Up" >Creating Your First Marketplace</ContentLink>
 
 ## Portal Settings
 The OrderCloud Portal has some basic settings for managing your profile. Here you can change your Username, Full Name, and Email Address.


### PR DESCRIPTION
Create your First Organization should be replaced by Create your First Marketplace with the same link as the next step at the bottom of the page.  I believe the market place needs to be created before the organization.