### PR TITLE
Client Secret

### DIFF
--- a/content/learn/getting-started/making-your-first-request.mdx
+++ b/content/learn/getting-started/making-your-first-request.mdx
@@ -30,6 +30,7 @@ In the example below we are retrieving, and in some examples also storing an acc
 Content-Type: application/x-www-form-urlencoded;\n
 {
     client_id: "INSERT_SHARED_API_CLIENT_ID",
+    client_secret: "INSERT_CLIENT_SECRET",
     grant_type: "password",
     username: "admin01",
     password: "INSERT_ADMIN_USER_PASSWORD",


### PR DESCRIPTION
The section on Retrieving an Access Token should mention that the client_secret also has to be sent in the POST request. Otherwise, you get back an invalid_client response.