### PR TITLE
Minor typo in Marketplaces

### DIFF
--- a/content/documents/globalization-multicurrency-multilanguage.mdx
+++ b/content/documents/globalization-multicurrency-multilanguage.mdx
@@ -1,7 +1,7 @@
 ---
 type:           article
 title:          Globalization for Marketplaces
-description:    Overview of new features to enable configuration of multi-currency and multi-language Marketpalces.
+description:    Overview of new features to enable configuration of multi-currency and multi-language Marketplaces.
 author:         mposthumus
 priority:       1
 publishDate:    2021-09-13
@@ -9,7 +9,7 @@ updatedDate:    2021-11-04
 tags:           ["Concepts", "Marketplaces", "Buyers", "Orders", "PriceSchedules"]
 ---
 
- New features to enable configuration of multi-currency and multi-language Marketpalces.
+ New features to enable configuration of multi-currency and multi-language Marketplaces.
 
 ## New Resource: `Locale`
 ```json


### PR DESCRIPTION
Fixed a minor typo in the word 'Marketplaces' (was 'Marketpalces')