### PR TITLE
OpenID Connect is an Authentication System

### DIFF
--- a/content/documents/authentication.mdx
+++ b/content/documents/authentication.mdx
@@ -15,7 +15,7 @@ Access tokens are what gives you _access_ to parts of the API and must be append
 
 ## OrderCloud Workflows
 
-OrderCloud's authentication system is built on top of an open authorization standard called [OAuth2](https://oauth.net/2/) which is increasingly becoming an industry standard for security and permission-based application experiences. OAuth2 provides five different workflows (ways of getting an access token). Additionally, OrderCloud has support for OpenID connect which is an authorization standard built on top of OAuth2 which enables single-sign-on and brings our grand tally up to 6 workflows.
+OrderCloud's authentication system is built on top of an open authorization standard called [OAuth2](https://oauth.net/2/) which is increasingly becoming an industry standard for security and permission-based application experiences. OAuth2 provides five different workflows (ways of getting an access token). Additionally, OrderCloud has support for OpenID connect which is an authentication standard built on top of OAuth2 which enables single-sign-on and brings our grand tally up to 6 workflows.
 
 ### Password Grant Type Workflow
 


### PR DESCRIPTION
Suggesting to change this sentence 
"Additionally, OrderCloud has support for OpenID connect which is an authorization standard built on top of OAuth2 which enables single-sign-on and brings our grand tally up to 6 workflows."
Proposing to change the word "authorization" to "authentication". OpenID was added to OAuth 2.0 because OAuth is a authorization protocol and everyone was using their own way to authenticate using OAuth. OpenID Connect standardized the authentication process.