### PR TITLE
OP-361: Add rss feeds for api and portal release notes

### DIFF
--- a/content/documents/authentication.mdx
+++ b/content/documents/authentication.mdx
@@ -27,6 +27,8 @@ This is the most common, a user logs in with their username and password.  A suc
 - Password
 - Grant Type (set to `password`)
 
+Note: If a ClientSecret is defined on the API Client, it will be required for all OAuth workflows
+
 <CodeExample
   title="Password Grant-Type Workflow"
   content={{

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -234,7 +234,7 @@ const toExport = {
                 }
               }
             `,
-            output: "/api-rss.xml",
+            output: "/rss/release-notes.xml",
             title: "OrderCloud API Release Notes",
             link: "https://feeds.feedburner.com/gatsby/blog",
           },
@@ -272,7 +272,7 @@ const toExport = {
                 }
               }
             `,
-            output: "/portal-rss.xml",
+            output: "/rss/portal-release-notes.xml",
             title: "OrderCloud Portal Release Notes",
             link: "https://feeds.feedburner.com/gatsby/blog",
           }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -185,6 +185,101 @@ const toExport = {
     `gatsby-plugin-typescript-checker`,
     `gatsby-transformer-sharp`,
     {
+      resolve: `gatsby-plugin-feed`,
+      options: {
+        query: `
+        {
+          site {
+            siteMetadata {
+              title
+              description
+              siteUrl
+              site_url: siteUrl
+            }
+          }
+        }
+        `,
+        feeds: [
+          {
+            serialize: ({ query: { site, allMdx } }) => {
+              return allMdx.nodes.map(node => {
+                return Object.assign({}, node.frontmatter, {
+                  title: "API v" + node.frontmatter.apiVersion + " Release Notes",
+                  date: node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + "/release-notes/v" + node.frontmatter.apiVersion,
+                })
+              })
+            },
+            query: `
+              {
+                allMdx(
+                  sort: { order: DESC, fields: [frontmatter___date] }
+                  filter: {
+                    fileAbsolutePath: { glob: "**/content/release-notes/**/*.mdx" }
+                  }
+                ) {
+                  nodes {
+                    id
+                    fileAbsolutePath
+                    body
+                    mdxAST
+                    frontmatter {
+                      apiVersion
+                      date: date(formatString: "MMMM DD, YYYY")
+                      year: date(formatString: "YYYY")
+                      month: date(formatString: "MM")
+                      day: date(formatString: "DD")
+                    }
+                  }
+                }
+              }
+            `,
+            output: "/api-rss.xml",
+            title: "OrderCloud API Release Notes",
+            link: "https://feeds.feedburner.com/gatsby/blog",
+          },
+          {
+            serialize: ({ query: { site, allMdx } }) => {
+              return allMdx.nodes.map(node => {
+                return Object.assign({}, node.frontmatter, {
+                  title: "API v" + node.frontmatter.apiVersion + " Release Notes",
+                  date: node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + "/portal-release-notes/v" + node.frontmatter.apiVersion,
+                })
+              })
+            },
+            query: `
+              {
+                allMdx(
+                  sort: { order: DESC, fields: [frontmatter___date] }
+                  filter: {
+                    fileAbsolutePath: { glob: "**/content/portal-release-notes/**/*.mdx" }
+                  }
+                ) {
+                  nodes {
+                    id
+                    fileAbsolutePath
+                    body
+                    mdxAST
+                    frontmatter {
+                      apiVersion
+                      date: date(formatString: "MMMM DD, YYYY")
+                      year: date(formatString: "YYYY")
+                      month: date(formatString: "MM")
+                      day: date(formatString: "DD")
+                    }
+                  }
+                }
+              }
+            `,
+            output: "/portal-rss.xml",
+            title: "OrderCloud Portal Release Notes",
+            link: "https://feeds.feedburner.com/gatsby/blog",
+          }
+        ],
+      },
+    },
+    {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `images`,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gatsby-image": "^2.2.37",
     "gatsby-plugin-algolia": "^0.5.0",
     "gatsby-plugin-catch-links": "^2.1.21",
+    "gatsby-plugin-feed": "^4.4.0",
     "gatsby-plugin-google-analytics": "^2.1.36",
     "gatsby-plugin-google-gtag": "^2.8.0",
     "gatsby-plugin-manifest": "^2.2.34",

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -239,7 +239,7 @@ class Footer extends React.Component<any> {
                 </Link>
                 <Link
                   className={classes.footerLinks}
-                  to="/portal-release-notes/v1.0.74"
+                  to="/portal-release-notes"
                 >
                   Portal Release Notes
                 </Link>

--- a/src/components/Layout/LayoutMenu.tsx
+++ b/src/components/Layout/LayoutMenu.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) =>
       paddingRight: 999,
       backgroundColor: theme.palette.background.default,
       borderLeft: `1px solid ${theme.palette.divider}`,
-      height: `calc(100vh - ${theme.spacing(8)}px)`,
+      height: `calc(100vh - ${theme.spacing(11)}px)`,
     },
     content: {
       padding: theme.spacing(4, 2.5, 4, 2.5),

--- a/src/components/Shared/RSSFeedLink.tsx
+++ b/src/components/Shared/RSSFeedLink.tsx
@@ -13,7 +13,7 @@ const RSSFeedLink: React.FunctionComponent<RSSFeedLinkProps> = (
   const classes = useStyles(props)
   const to = props.to
   return (
-    <Link to={to}><Typography className={classes.rssLink} variant="body2"><RssFeed fontSize="small" /> Subscribe to RSS Feed</Typography></Link>
+    <a href={to}><Typography className={classes.rssLink} variant="body2"><RssFeed fontSize="small" /> Subscribe to RSS Feed</Typography></a>
   )
 }
 

--- a/src/components/Shared/RSSFeedLink.tsx
+++ b/src/components/Shared/RSSFeedLink.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import { createStyles, makeStyles, Theme, Typography } from '@material-ui/core'
+import { RssFeed } from '@material-ui/icons'
+
+interface RSSFeedLinkProps {
+  to: string
+}
+
+const RSSFeedLink: React.FunctionComponent<RSSFeedLinkProps> = (
+  props: any
+) => {
+  const classes = useStyles(props)
+  const to = props.to
+  return (
+    <Link to={to}><Typography className={classes.rssLink} variant="body2"><RssFeed fontSize="small" /> Subscribe to RSS Feed</Typography></Link>
+  )
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    rssLink: {
+      display: "flex",
+      alignItems: "center",
+      color: theme.palette.grey[500],
+      marginTop: theme.spacing(3)
+    }
+  })
+)
+export default RSSFeedLink

--- a/src/components/Templates/PortalReleaseNotesTemplate.tsx
+++ b/src/components/Templates/PortalReleaseNotesTemplate.tsx
@@ -17,6 +17,7 @@ import Layout from '../Layout/Layout'
 import LayoutContainer from '../Layout/LayoutContainer'
 import LayoutMain from '../Layout/LayoutMain'
 import LayoutMenu from '../Layout/LayoutMenu'
+import RSSFeedLink from '../Shared/RSSFeedLink'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -205,6 +206,7 @@ function PortalReleaseNotesComponent(props: any) {
               </Collapse>
             </React.Fragment>
           ))}
+          <RSSFeedLink to="/rss/portal-release-notes.xml" />
         </LayoutMenu>
       </LayoutContainer>
     </Layout>

--- a/src/components/Templates/ReleaseNotes.tsx
+++ b/src/components/Templates/ReleaseNotes.tsx
@@ -5,7 +5,7 @@ import {
   Theme,
   Typography,
 } from '@material-ui/core'
-import { ExpandLess, ExpandMore } from '@material-ui/icons'
+import { ExpandLess, ExpandMore, RssFeed } from '@material-ui/icons'
 import { graphql, Link } from 'gatsby'
 import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer'
 import { groupBy, map, sortBy } from 'lodash'
@@ -17,6 +17,7 @@ import Layout from '../Layout/Layout'
 import LayoutContainer from '../Layout/LayoutContainer'
 import LayoutMain from '../Layout/LayoutMain'
 import LayoutMenu from '../Layout/LayoutMenu'
+import RSSFeedLink from '../Shared/RSSFeedLink'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -205,6 +206,7 @@ function ReleaseNotesComponent(props: any) {
               </Collapse>
             </React.Fragment>
           ))}
+          <RSSFeedLink to="/rss/release-notes.xml" />
         </LayoutMenu>
       </LayoutContainer>
     </Layout>

--- a/src/components/Templates/ReleaseNotes.tsx
+++ b/src/components/Templates/ReleaseNotes.tsx
@@ -5,7 +5,7 @@ import {
   Theme,
   Typography,
 } from '@material-ui/core'
-import { ExpandLess, ExpandMore, RssFeed } from '@material-ui/icons'
+import { ExpandLess, ExpandMore } from '@material-ui/icons'
 import { graphql, Link } from 'gatsby'
 import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer'
 import { groupBy, map, sortBy } from 'lodash'

--- a/src/pages/portal-release-notes.tsx
+++ b/src/pages/portal-release-notes.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Redirect } from '@reach/router'
+import { graphql, useStaticQuery } from 'gatsby'
+
+const PortalReleaseNotes = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      allMdx(
+        sort: { fields: frontmatter___date, order: DESC }
+        filter: {
+          fileAbsolutePath: { glob: "**/content/portal-release-notes/**/*.mdx" }
+        }
+        limit: 1
+      ) {
+        edges {
+          node {
+            id
+            frontmatter {
+              apiVersion
+            }
+          }
+        }
+      }
+    }
+  `)
+  const mostRecentApiVersionWithReleaseNote =
+    data.allMdx.edges[0].node.frontmatter.apiVersion
+  return (
+    <Redirect
+      to={`/portal-release-notes/v${mostRecentApiVersionWithReleaseNote}`}
+      noThrow
+    />
+  )
+}
+
+export default PortalReleaseNotes


### PR DESCRIPTION
## Adds RSS feed for:
- OrderCloud API Release Notes (/rss/release-notes.xml)
- OrderCloud Portal Release Notes (/rss/portal-release-notes.xml)