### PR TITLE
remove internal properties from oidc documentation

### DIFF
--- a/content/documents/sso-via-openid-connect.mdx
+++ b/content/documents/sso-via-openid-connect.mdx
@@ -145,11 +145,8 @@ Using the token response from your IDP, you can decode the token and use the dat
 
 ```json
 {
-  "HttpStatusCode": 200,
   "Username": "neworderclouduser", // username of the user created in OrderCloud
-  "ErrorMessage": null,
-  "UnhandledErrorBody": null,
-  "xp": {}
+  "ErrorMessage": null
 }
 ```
 
@@ -172,10 +169,7 @@ Using the token response from your IDP, you can decode the token and use the dat
 
 ```json
 {
-  "HttpStatusCode": 200,
-  "ErrorMessage": null,
-  "UnhandledErrorBody": null,
-  "xp": {}
+  "ErrorMessage": null
 }
 ```
 


### PR DESCRIPTION
Confirmed with platform team that these can not be set by user, not are they shown anywhere. Only used for internal storage