### PR TITLE
Update conventions.mdx

### DIFF
--- a/content/learn/ordercloud-basics/conventions.mdx
+++ b/content/learn/ordercloud-basics/conventions.mdx
@@ -31,7 +31,7 @@ Most resources that map to an entity of some sort (Orders, Users, Addresses, etc
 
 ## Error Handling
 
-For all unsuccessful requests, we attempt to return the [most appropriate HTTP status in the 400 range](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error). Only when something goes terribly wrong on our end will you get a 500 response. And so long as our platform is responding (i.e. returning anything in the 4xx range or 500), you can count on the response body taking a standard shape.
+For all unsuccessful requests, we attempt to return the [most appropriate HTTP status in the 400 range](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error). So long as our platform is responding (i.e. returning anything in the 4xx range or 500), you can count on the response body taking a standard shape.
 
 ## HTTP Methods
 


### PR DESCRIPTION
Wording 'Only when something goes terribly wrong on our end will you get a 500 response' is duplicated on the same page under the 'HTTP Status Code Summary' section.. could just be removed here?