### PR TITLE
Add search for tags in the knowledge base

### DIFF
--- a/src/pages/knowledge-base.tsx
+++ b/src/pages/knowledge-base.tsx
@@ -14,11 +14,12 @@ import {
   Typography,
   Breadcrumbs,
   Hidden,
+  TextField,
 } from '@material-ui/core/'
 import { Code, Description } from '@material-ui/icons'
 import { graphql, Link, useStaticQuery } from 'gatsby'
 import { flatten, intersection } from 'lodash'
-import React, { Fragment, FunctionComponent, useMemo } from 'react'
+import React, { Fragment, FunctionComponent, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import Layout from '../components/Layout/Layout'
 import LayoutContainer from '../components/Layout/LayoutContainer'
@@ -93,6 +94,10 @@ const KnowledgeBase: FunctionComponent<KnowledgeBaseProps> = (
   // const [selectedTags, setSelectedTags] = useState<string[]>(
   //   params.has('t') ? params.get('t').split(',') : []
   // )
+  const [tagSearch, setTagSearch] = useState<string>(``)
+  const handleTagSearch = (e: any) => {
+    setTagSearch(e.target.value)
+  }
   const data: QueryResult = useStaticQuery(graphql`
     query {
       allMdx(
@@ -128,7 +133,8 @@ const KnowledgeBase: FunctionComponent<KnowledgeBaseProps> = (
 
   const availableTags = useMemo(() => {
     const tagsArray = data.allMdx.edges.map(n => n.node.frontmatter.tags)
-    const flattenedTags = flatten(tagsArray)
+    let flattenedTags = flatten(tagsArray)
+    if (tagSearch) flattenedTags = flattenedTags.filter(t => t.toLowerCase().includes(tagSearch.toLowerCase()))
     const result: any = {}
     flattenedTags.forEach(t => {
       if (result[t]) {
@@ -138,7 +144,7 @@ const KnowledgeBase: FunctionComponent<KnowledgeBaseProps> = (
       }
     })
     return Object.entries(result)
-  }, [data.allMdx.edges])
+  }, [data.allMdx.edges, tagSearch])
 
   // const handleTagToggle = (tag: string) => () => {
   //   setSelectedTags(s =>
@@ -199,6 +205,7 @@ const KnowledgeBase: FunctionComponent<KnowledgeBaseProps> = (
           <Typography variant="h5" paragraph>
             Filter by tag:
           </Typography>
+          <TextField margin="normal" placeholder="Search tags..." type="text" value={tagSearch} onChange={handleTagSearch} />
           <Container disableGutters>
             {availableTags
               .sort((a: any, b: any) => b[1] - a[1])


### PR DESCRIPTION
- Add a simple client side search to the tags in the Knowledge Base.  As we continue adding articles, the list of tags end up quite long, reducing usability.