### PR TITLE
Update making-your-product-visible.mdx

### DIFF
--- a/content/learn/product-catalogs/making-your-product-visible.mdx
+++ b/content/learn/product-catalogs/making-your-product-visible.mdx
@@ -19,7 +19,7 @@ For this reason many developers overlook the fact that they need to explicitly a
 <CodeExample
   title="Assign the product to the default catalog"
   content={{
-    http: `POST https://sandboxapi.ordercloud.io/v1/catalogs/productassignments HTTP/1.1
+    http: `POST https://sandboxapi.ordercloud.io/v1/catalogs/products/assignments HTTP/1.1
 Authorization: Bearer INSERT_ACCESS_TOKEN_HERE
 Content-Type: application/json; charset=UTF-8;\n
 {


### PR DESCRIPTION
Updated product assignment API to match currently documented one [here](https://ordercloud.io/api-reference/product-catalogs/products/save-assignment).  The legacy API will accept a GET request, whereas the new one will return a 405 Method Not Allowed if the user attempts a GET.   Allowing GET can cause user confusion, since the update will not get applied. See this Stack Exchange answer: https://stackoverflow.com/a/74891802/402949