### PR TITLE
Premium search for orders exists

### DIFF
--- a/content/documents/introducing-premium-search.mdx
+++ b/content/documents/introducing-premium-search.mdx
@@ -24,7 +24,7 @@ Premium Search is the next evolution in search technology offered by the OrderCl
 
 ## What areas of the API does this affect?
 
-Premium Search is currently available only in buyer-side product lists, i.e. <Link to="/api-reference/me-and-my-stuff/my-products">`me/products`</Link>. Plans are in the works to roll it out for seller-side products (endpoints under <Link to="/api-reference/product-catalogs/products">`/products`</Link>), as well as <Link to="/api-reference/orders-and-fulfillment/orders">`/orders`</Link> endpoints, in the coming months.
+Premium Search is currently available in buyer-side product lists, i.e. <Link to="/api-reference/me-and-my-stuff/my-products">`me/products`</Link>, seller-side products (endpoints under <Link to="/api-reference/product-catalogs/products">`/products`</Link>), as well as <Link to="/api-reference/orders-and-fulfillment/orders">`/orders`</Link> endpoints.
 
 ## Is there an add-on cost?
 


### PR DESCRIPTION
Under "what areas of the API does this affect", update "Premium Search is currently available only in buyer-side product lists" and "in the coming months" to reflect that these are available. See https://ordercloud.io/knowledge-base/new-for-premium-search and https://ordercloud.io/knowledge-base/order-search.